### PR TITLE
楽天スクレイピング修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -36,16 +36,16 @@ http("scraping-rakuten-product-detail", async (req, res) => {
   const imageUrls = await getImageUrls()
 
   const getItemDesc = async (): Promise<{
-    itemDescText?: string
+    itemDescText: string | null
     imageUrls: string[]
   }> => {
     try {
       await page.waitForSelector(".item_desc")
 
-      const itemDesc = await page.$(".item_desc")
-      const itemDescText: string | undefined = await (
-        await itemDesc?.getProperty("innerText")
-      )?.jsonValue()
+      const itemDescText: string | null = await page.$eval(
+        ".item_desc",
+        (el) => el.textContent
+      )
 
       const imageUrls = await page.$$eval("span.item_desc img", (list) =>
         list.map((el) => (el as HTMLImageElement).src)

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,7 +24,7 @@ http("scraping-rakuten-product-detail", async (req, res) => {
 
   const getImageUrls = async () => {
     try {
-      await page.waitForSelector(".sale_desc")
+      await page.waitForSelector(".sale_desc", { timeout: 10000 })
       return await page.$$eval("span.sale_desc img", (list) =>
         list.map((el) => (el as HTMLImageElement).src)
       )
@@ -40,8 +40,7 @@ http("scraping-rakuten-product-detail", async (req, res) => {
     imageUrls: string[]
   }> => {
     try {
-      await page.waitForSelector(".item_desc")
-
+      await page.waitForSelector(".item_desc", { timeout: 10000 })
       const itemDescText: string | null = await page.$eval(
         ".item_desc",
         (el) => el.textContent

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,16 +21,44 @@ http("scraping-rakuten-product-detail", async (req, res) => {
   const browser = await puppeteer.launch(options)
   const page = await browser.newPage()
   await page.goto(body.siteUrl)
-  await page.waitForSelector(".sale_desc")
 
-  const imageUrls = await page.$$eval("span.sale_desc img", (list) =>
-    list.map((el) => (el as HTMLImageElement).src)
-  )
+  const getImageUrls = async () => {
+    try {
+      await page.waitForSelector(".sale_desc")
+      return await page.$$eval("span.sale_desc img", (list) =>
+        list.map((el) => (el as HTMLImageElement).src)
+      )
+    } catch (e) {
+      console.log(e)
+      return []
+    }
+  }
+  const imageUrls = await getImageUrls()
 
-  const itemDesc = await page.$(".item_desc")
-  const itemDsecText: string | undefined = await (
-    await itemDesc?.getProperty("innerText")
-  )?.jsonValue()
+  const getItemDesc = async (): Promise<{
+    itemDescText?: string
+    imageUrls: string[]
+  }> => {
+    try {
+      await page.waitForSelector(".item_desc")
+
+      const itemDesc = await page.$(".item_desc")
+      const itemDescText: string | undefined = await (
+        await itemDesc?.getProperty("innerText")
+      )?.jsonValue()
+
+      const imageUrls = await page.$$eval("span.item_desc img", (list) =>
+        list.map((el) => (el as HTMLImageElement).src)
+      )
+
+      return { itemDescText, imageUrls }
+    } catch (e) {
+      console.log(e)
+      return { itemDescText: "", imageUrls: [] }
+    }
+  }
+
+  const { itemDescText, imageUrls: itemDescImageUrls } = await getItemDesc()
 
   const itemName = await page.$(".normal_reserve_item_name")
   const itemNameText: string | undefined = await (
@@ -45,9 +73,9 @@ http("scraping-rakuten-product-detail", async (req, res) => {
 
   res.status(200).json({
     item: {
-      imageUrls,
+      imageUrls: [...imageUrls, ...itemDescImageUrls],
       name: itemNameText?.trim(),
-      description: itemDsecText?.trim(),
+      description: itemDescText?.trim(),
       price: `${price}円`,
     },
   })


### PR DESCRIPTION
## 変更内容
- sale_descがない商品ページでも情報を取得できるように
- item_desc内の画像も取得できるように

waitForSelectしている要素がない場合、タイムアウトエラーで落ちていましたが、エラーをキャッチするようにしてその他の情報は返せるように修正しました。