### PR TITLE
楽天の商品レビューを取得するスクレイピング修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -101,37 +101,28 @@ http("scraping-rakuten-product-reviews", async (req, res) => {
   page.setDefaultNavigationTimeout(0)
   await page.goto(body.siteUrl)
 
-  const isExistSelector = async (selector: string) => {
+  // hrefに「https://review.rakuten.co.jp/item」を含むaタグのhref属性を取得する
+  // NOTE: aタグをクリックして遷移すると、ページ遷移処理が上手く動作しないときがあるため、hrefを取得して直接遷移する
+  const getReviewsUrl = async (selector: string) => {
     try {
       await page.waitForSelector(selector, { timeout: 10000 })
-      return true
+      return await page.$eval(selector, (el) => el.getAttribute("href"))
     } catch (e) {
       console.log(e)
-      return false
+      return null
     }
   }
 
-  const isExistReviewLink = async () => {
-    const reviewLink = await isExistSelector("span[irc='SeeReviewButton'] a")
-    return reviewLink
-  }
+  const [seeReviewButtonLink, pageItemReviewsLink] = await Promise.all([
+    getReviewsUrl(
+      "span[irc='SeeReviewButton'] a[href^='https://review.rakuten.co.jp/item']"
+    ),
+    getReviewsUrl(
+      ".page_item_reviews a[href^='https://review.rakuten.co.jp/item']"
+    ),
+  ])
 
-  // レビューページのリンクを持つ要素が表示されるまで待つ
-  const isExistReviewLinkResult = await isExistReviewLink()
-  if (!isExistReviewLinkResult) {
-    await browser.close()
-    res.status(200).json({
-      comprehensiveEval: "",
-      totalEvalCount: "",
-      reviews: [],
-    })
-  }
-
-  // hrefに「https://review.rakuten.co.jp/item」を含むaタグのhref属性を取得する
-  // NOTE: aタグをクリックして遷移すると、ページ遷移処理が上手く動作しないときがあるため、hrefを取得して直接遷移する
-  const href = await page.$eval("span[irc='SeeReviewButton'] a", (el) =>
-    el.getAttribute("href")
-  )
+  const href = seeReviewButtonLink || pageItemReviewsLink
 
   if (href == null) {
     await browser.close()

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,12 +112,8 @@ http("scraping-rakuten-product-reviews", async (req, res) => {
   }
 
   const isExistReviewLink = async () => {
-    const [pageItemReviews, reviewButton, reviewLink] = await Promise.all([
-      isExistSelector(".page_item_reviews"),
-      isExistSelector(".button--3SNaj"),
-      isExistSelector(".link--_SR9y"),
-    ])
-    return pageItemReviews || reviewButton || reviewLink
+    const reviewLink = await isExistSelector("span[irc='SeeReviewButton'] a")
+    return reviewLink
   }
 
   // レビューページのリンクを持つ要素が表示されるまで待つ
@@ -133,9 +129,8 @@ http("scraping-rakuten-product-reviews", async (req, res) => {
 
   // hrefに「https://review.rakuten.co.jp/item」を含むaタグのhref属性を取得する
   // NOTE: aタグをクリックして遷移すると、ページ遷移処理が上手く動作しないときがあるため、hrefを取得して直接遷移する
-  const href = await page.$eval(
-    'a[href^="https://review.rakuten.co.jp/item"]',
-    (el) => el.getAttribute("href")
+  const href = await page.$eval("span[irc='SeeReviewButton'] a", (el) =>
+    el.getAttribute("href")
   )
 
   if (href == null) {


### PR DESCRIPTION
## 概要
楽天の商品レビューを取得するスクレイピングを修正しました。

ref: https://www.notion.so/anycloud/f32faf31f5c9487199ceb8a22d668856?pvs=4#560ecd6c65d247ca97162e9e7947088b

## その他
Promise.allより便利なやつはないか調べたところ、`Promise.any`が使えそうでした。
https://developer.mozilla.org/ja/docs/Web/JavaScript/Reference/Global_Objects/Promise/any
しかし、`compilerOptions`の`target`を`2021`に変更しなければいけなく、影響範囲が広いので一旦見送りにしてます。
