### PR TITLE
reviewPagerSectionClassNameがないときにも、空のレスポンスを返すように修正

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -236,7 +236,18 @@ http('scraping-rakuten-product-reviews', async (req, res) => {
   const reviewItemClassName = '.revRvwUserEntryCmt'
   const reviewPagerSectionClassName = '.revPagerSec'
   // レビューのページャセクションが表示されるまで待つ
-  await page.waitForSelector(reviewPagerSectionClassName, { timeout: 10000 })
+  try {
+    await page.waitForSelector(reviewPagerSectionClassName, { timeout: 10000 })
+  } catch (e) {
+    console.log(e)
+    await browser.close()
+    res.status(200).json({
+      comprehensiveEval: '',
+      totalEvalCount: '',
+      reviews: [],
+      eachRateReviews: { 1: [], 2: [], 3: [], 4: [], 5: [] },
+    })
+  }
 
   // 総合評価の取得
   const comprehensiveEvalElement = await page.$('.revEvaNumber')
@@ -274,8 +285,14 @@ http('scraping-rakuten-product-reviews', async (req, res) => {
   const eachRateReviews: { [key: number]: string[] } = {}
 
   for (let i = 1; i <= 5; i++) {
-    await gotoRatePage(i)
-    eachRateReviews[i] = await getReviews()
+    try {
+      await gotoRatePage(i)
+      eachRateReviews[i] = await getReviews()
+    } catch (e) {
+      console.log(e)
+      eachRateReviews[i] = []
+      continue
+    }
   }
 
   await browser.close()


### PR DESCRIPTION
一旦雑ですが、以下の商品レビュー取得でエラーが出ないように対応しました。
https://item.rakuten.co.jp/medela/101041159/

その他、3件の商品も正常にレビューを取得できることを確認しています。
https://item.rakuten.co.jp/chimoto-coffee/10000558/?s-id=top_normal_browsehist&xuseflg_ichiba01=10000571
https://item.rakuten.co.jp/kadenrand/7088061/
https://item.rakuten.co.jp/plywood/14949001/?s-id=top_normal_browsehist&xuseflg_ichiba01=10012643